### PR TITLE
Maintainance: Removed ct.use_numpy_matrix(flag=False) in linearetc.py

### DIFF
--- a/ETCetera/Systems/linearetc.py
+++ b/ETCetera/Systems/linearetc.py
@@ -18,7 +18,7 @@ from .etcutil import is_positive_definite
 
 
 ''' Important to prevent legacy Matrix object returned from control lib'''
-ct.use_numpy_matrix(flag=False)
+# ct.use_numpy_matrix(flag=False)  # Remove this, this command is depreciated
 
 ''' Settings for solvers '''
 _MAX_TRIES_TIGHT_LYAPUNOV = 10


### PR DESCRIPTION
This command is depreciated