### PR TITLE
Maintenance: Removed 'from scipy.sparse.linalg.eigen.arpack import Ar…

### DIFF
--- a/ETCetera/util/etcgraph.py
+++ b/ETCetera/util/etcgraph.py
@@ -11,7 +11,7 @@ import numpy as np
 import scipy.sparse.linalg as sla
 import scipy.sparse as sparse
 import scipy.linalg as la
-from scipy.sparse.linalg.eigen.arpack import ArpackNoConvergence
+# from scipy.sparse.linalg.eigen.arpack import ArpackNoConvergence  # Remove this, this package is unused and no longer exists
 
 
 class TrafficAutomaton:


### PR DESCRIPTION
…packNoConvergence', as the package no longer exists (and was not used)